### PR TITLE
Fixed error in reference to _back - Fix macos/lang compile

### DIFF
--- a/include/DiscreteVerification/DataStructures/light_deque.h
+++ b/include/DiscreteVerification/DataStructures/light_deque.h
@@ -51,7 +51,7 @@ public:
     
     T back() const {
         assert(!empty());
-        return _data[back-1];
+        return _data[_back-1];
     }
 
     void pop_front() {


### PR DESCRIPTION
In MacOS / clang it catches the error that back was using non existing "back" variable. Fixed to _back.