### PR TITLE
Truncate SMC run lengths and durations to the query bound, and unified weight format

### DIFF
--- a/src/Core/TAPN/TimedArcPetriNet.cpp
+++ b/src/Core/TAPN/TimedArcPetriNet.cpp
@@ -347,7 +347,10 @@ namespace TAPN {
             out << "<transition player=\"" << (transition->isControllable() ? 0 : 1)
                 << "\" id=\"" << transition->getName() << "\" name=\"" << transition->getName()
                 << "\" urgent=\"" << std::boolalpha << transition->isUrgent() 
-                << "\" weight=\"" << transition->getWeight()
+                << "\" weight=\"" << (
+                    transition->getWeight() == std::numeric_limits<double>::infinity() ?
+                    "Infinity" : std::to_string(transition->getWeight())
+                )
                 << "\" firingMode=\"" << SMC::firingModeName(transition->getFiringMode())
                 << "\" " << transition->getDistribution().toXML()
                 << ">\n";

--- a/src/Core/TAPN/TimedArcPetriNet.cpp
+++ b/src/Core/TAPN/TimedArcPetriNet.cpp
@@ -349,7 +349,7 @@ namespace TAPN {
                 << "\" urgent=\"" << std::boolalpha << transition->isUrgent() 
                 << "\" weight=\"" << (
                     transition->getWeight() == std::numeric_limits<double>::infinity() ?
-                    "Infinity" : std::to_string(transition->getWeight())
+                    "inf" : std::to_string(transition->getWeight())
                 )
                 << "\" firingMode=\"" << SMC::firingModeName(transition->getFiringMode())
                 << "\" " << transition->getDistribution().toXML()


### PR DESCRIPTION
Fixed run statistics being greater than the query bound, and https://bugs.launchpad.net/tapaal/+bug/2081687 