### PR TITLE
Fixed inhibitors when a transition have no input arcs preset

### DIFF
--- a/include/Core/TAPN/TimedTransition.hpp
+++ b/include/Core/TAPN/TimedTransition.hpp
@@ -68,7 +68,9 @@ namespace VerifyTAPN {
 
             inline unsigned int getNumberOfInputArcs() const { return preset.size(); };
 
-            inline unsigned int getNumberOfTransportArcs() const { return transportArcs.size(); };
+            inline unsigned int getNumberOfTransportArcs() const { return transportArcs.size(); }
+
+            inline unsigned int getNumberOfInhibitorArcs() const { return inhibitorArcs.size(); }
 
             inline bool isConservative() const { return preset.size() == postset.size(); }
 

--- a/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
+++ b/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
@@ -25,7 +25,7 @@ namespace VerifyTAPN {
             double originMaxDelay = _origin->availableDelay();
             std::vector<interval<double>> invInterval = { interval<double>(0, originMaxDelay) };
             for(auto transi : _tapn.getTransitions()) {
-                if(transi->getPresetSize() == 0) {
+                if(transi->getPresetSize() == 0 && transi->getNumberOfInhibitorArcs() == 0) {
                     _defaultTransitionIntervals[transi->getIndex()] = invInterval;
                 } else {
                     std::vector<interval<double>> firingDates = transitionFiringDates(transi);
@@ -87,7 +87,7 @@ namespace VerifyTAPN {
             bool deadlocked = true;
             for(auto transi : _tapn.getTransitions()) {
                 int i = transi->getIndex();
-                if(transi->getPresetSize() == 0) {
+                if(transi->getPresetSize() == 0 && transi->getNumberOfInhibitorArcs() == 0) {
                     _transitionIntervals[i] = invInterval;
                 } else {
                     std::vector<interval<double>> firingDates = transitionFiringDates(transi);


### PR DESCRIPTION
Fixed a bug when a transition had no preset of input arcs, it would be always enabled no matter inhibitor arcs