### PR TITLE
Computing place and transition statistics when doing SMC

### DIFF
--- a/include/DiscreteVerification/Generators/SMCRunGenerator.h
+++ b/include/DiscreteVerification/Generators/SMCRunGenerator.h
@@ -25,6 +25,7 @@ namespace VerifyTAPN {
             : _tapn(tapn)
             , _defaultTransitionIntervals(tapn.getTransitions().size()) 
             , _transitionsStatistics(tapn.getTransitions().size(), 0)
+            , _currentPlacesStatistics(tapn.getNumberOfPlaces(), 0)
             , _placesStatistics(tapn.getNumberOfPlaces(), 0)
             , _numericPrecision(numericPrecision)
             {
@@ -71,7 +72,7 @@ namespace VerifyTAPN {
             int getRunSteps() const;
 
             void printTransitionStatistics(std::ostream &out, const size_t& n = 1) const;
-            void printPlaceStatistics(std::ostream &out) const;
+            void printPlaceStatistics(std::ostream &out, const size_t& n = 1) const;
             void mergeStatistics(const SMCRunGenerator& other);
 
             std::stack<RealMarking*> getTrace() const;
@@ -90,6 +91,7 @@ namespace VerifyTAPN {
             std::vector<std::vector<Util::interval<double>>> _transitionIntervals; // Type not pretty, but need disjoint intervals
             std::vector<double> _dates_sampled;
             std::vector<uint32_t> _transitionsStatistics;
+            std::vector<uint32_t> _currentPlacesStatistics;
             std::vector<uint32_t> _placesStatistics;
             RealMarking* _origin;
             RealMarking* _parent;

--- a/include/DiscreteVerification/Generators/SMCRunGenerator.h
+++ b/include/DiscreteVerification/Generators/SMCRunGenerator.h
@@ -25,6 +25,7 @@ namespace VerifyTAPN {
             : _tapn(tapn)
             , _defaultTransitionIntervals(tapn.getTransitions().size()) 
             , _transitionsStatistics(tapn.getTransitions().size(), 0)
+            , _placesStatistics(tapn.getNumberOfPlaces(), 0)
             , _numericPrecision(numericPrecision)
             {
                 std::random_device rd;
@@ -69,7 +70,9 @@ namespace VerifyTAPN {
             double getRunDelay() const;
             int getRunSteps() const;
 
-            void printTransitionStatistics(std::ostream &out) const;
+            void printTransitionStatistics(std::ostream &out, const size_t& n = 1) const;
+            void printPlaceStatistics(std::ostream &out) const;
+            void mergeStatistics(const SMCRunGenerator& other);
 
             std::stack<RealMarking*> getTrace() const;
 
@@ -87,6 +90,7 @@ namespace VerifyTAPN {
             std::vector<std::vector<Util::interval<double>>> _transitionIntervals; // Type not pretty, but need disjoint intervals
             std::vector<double> _dates_sampled;
             std::vector<uint32_t> _transitionsStatistics;
+            std::vector<uint32_t> _placesStatistics;
             RealMarking* _origin;
             RealMarking* _parent;
             double _lastDelay = 0;

--- a/include/DiscreteVerification/VerificationTypes/SMCVerification.hpp
+++ b/include/DiscreteVerification/VerificationTypes/SMCVerification.hpp
@@ -31,6 +31,7 @@ class SMCVerification : public Verification<RealMarking> {
 
         virtual void printStats() override;
         void printTransitionStatistics() const override;
+        void printPlaceStatistics() override;
 
         unsigned int maxUsedTokens() override;
         void setMaxTokensIfGreater(unsigned int i);

--- a/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
+++ b/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
@@ -481,7 +481,7 @@ namespace VerifyTAPN {
         }
 
         void SMCRunGenerator::printPlaceStatistics(std::ostream &out) const {
-            out << std::endl << "PLACE STATISTICS";
+            out << std::endl << "PLACE-BOUND STATISTICS";
             for (unsigned int i = 0; i < _placesStatistics.size(); i++) {
                 if ((i) % 6 == 0) {
                     out << std::endl;

--- a/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
+++ b/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
@@ -32,9 +32,6 @@ namespace VerifyTAPN {
                     _defaultTransitionIntervals[transi->getIndex()] = Util::setIntersection(firingDates, invInterval);
                 }
             }
-            for(auto place : _tapn.getPlaces()) {
-                _placesStatistics[place->getIndex()] = parent->numberOfTokensInPlace(place->getIndex());
-            }
             reset();
         }
 
@@ -70,6 +67,10 @@ namespace VerifyTAPN {
                                 );
             }
             _parent->setDeadlocked(deadlocked);
+            for(int i = 0 ; i < _currentPlacesStatistics.size() ; i++) {
+                _placesStatistics[i] += _currentPlacesStatistics[i];
+                _currentPlacesStatistics[i] = _origin->numberOfTokensInPlace(i);
+            }
         }
 
         SMCRunGenerator SMCRunGenerator::copy() const
@@ -440,15 +441,15 @@ namespace VerifyTAPN {
                 RealToken token = RealToken(0.0, output->getWeight());
                 child->addTokenInPlace(place, token);
                 int place_i = place.getIndex();
-                if(child->numberOfTokensInPlace(place_i) > _placesStatistics[place_i]) {
-                    _placesStatistics[place_i] = child->numberOfTokensInPlace(place_i);
+                if(child->numberOfTokensInPlace(place_i) > _currentPlacesStatistics[place_i]) {
+                    _currentPlacesStatistics[place_i] = child->numberOfTokensInPlace(place_i);
                 }
             }
             for (auto [dest, token] : toCreate) {
                 child->addTokenInPlace(dest, token);
                 int place_i = dest.getIndex();
-                if(child->numberOfTokensInPlace(place_i) > _placesStatistics[place_i]) {
-                    _placesStatistics[place_i] = child->numberOfTokensInPlace(place_i);
+                if(child->numberOfTokensInPlace(place_i) > _currentPlacesStatistics[place_i]) {
+                    _currentPlacesStatistics[place_i] = child->numberOfTokensInPlace(place_i);
                 }
             }
             return child;
@@ -471,23 +472,23 @@ namespace VerifyTAPN {
             for (unsigned int i = 0; i < _transitionsStatistics.size(); i++) {
                 if ((i) % 6 == 0) {
                     out << std::endl;
-                    out << "<" << _tapn.getTransitions()[i]->getName() << ":" << (_transitionsStatistics[i] / n) << ">";
+                    out << "<" << _tapn.getTransitions()[i]->getName() << ":" << (((double) _transitionsStatistics[i]) / n) << ">";
                 } else {
-                    out << " <" << _tapn.getTransitions()[i]->getName() << ":" << (_transitionsStatistics[i] / n) << ">";
+                    out << " <" << _tapn.getTransitions()[i]->getName() << ":" << (((double) _transitionsStatistics[i]) / n) << ">";
                 }
             }
             out << std::endl;
             out << std::endl;
         }
 
-        void SMCRunGenerator::printPlaceStatistics(std::ostream &out) const {
+        void SMCRunGenerator::printPlaceStatistics(std::ostream &out, const size_t& n) const {
             out << std::endl << "PLACE-BOUND STATISTICS";
             for (unsigned int i = 0; i < _placesStatistics.size(); i++) {
                 if ((i) % 6 == 0) {
                     out << std::endl;
-                    out << "<" << _tapn.getPlaces()[i]->getName() << ":" << _placesStatistics[i] << ">";
+                    out << "<" << _tapn.getPlaces()[i]->getName() << ":" << (((double) _placesStatistics[i]) / n) << ">";
                 } else {
-                    out << " <" << _tapn.getPlaces()[i]->getName() << ":" << _placesStatistics[i] << ">";
+                    out << " <" << _tapn.getPlaces()[i]->getName() << ":" << (((double) _placesStatistics[i]) / n) << ">";
                 }
             }
             out << std::endl;
@@ -499,10 +500,13 @@ namespace VerifyTAPN {
                 _transitionsStatistics[i] += other._transitionsStatistics[i];
             }
             for(int i = 0 ; i < _placesStatistics.size() ; i++) {
-                if(_placesStatistics[i] < other._placesStatistics[i]) {
-                    _placesStatistics[i] = other._placesStatistics[i];
-                }
+                _placesStatistics[i] += other._placesStatistics[i];
             }
+            // for(int i = 0 ; i < _placesStatistics.size() ; i++) {
+            //     if(_placesStatistics[i] < other._placesStatistics[i]) {
+            //         _placesStatistics[i] = other._placesStatistics[i];
+            //     }
+            // }   
         }
 
         std::stack<RealMarking*> SMCRunGenerator::getTrace() const {

--- a/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
+++ b/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
@@ -472,9 +472,9 @@ namespace VerifyTAPN {
             for (unsigned int i = 0; i < _transitionsStatistics.size(); i++) {
                 if ((i) % 6 == 0) {
                     out << std::endl;
-                    out << "<" << _tapn.getTransitions()[i]->getName() << ":" << (((double) _transitionsStatistics[i]) / n) << ">";
+                    out << "<" << _tapn.getTransitions()[i]->getName() << ";" << (((double) _transitionsStatistics[i]) / n) << ">";
                 } else {
-                    out << " <" << _tapn.getTransitions()[i]->getName() << ":" << (((double) _transitionsStatistics[i]) / n) << ">";
+                    out << " <" << _tapn.getTransitions()[i]->getName() << ";" << (((double) _transitionsStatistics[i]) / n) << ">";
                 }
             }
             out << std::endl;
@@ -486,9 +486,9 @@ namespace VerifyTAPN {
             for (unsigned int i = 0; i < _placesStatistics.size(); i++) {
                 if ((i) % 6 == 0) {
                     out << std::endl;
-                    out << "<" << _tapn.getPlaces()[i]->getName() << ":" << (((double) _placesStatistics[i]) / n) << ">";
+                    out << "<" << _tapn.getPlaces()[i]->getName() << ";" << (((double) _placesStatistics[i]) / n) << ">";
                 } else {
-                    out << " <" << _tapn.getPlaces()[i]->getName() << ":" << (((double) _placesStatistics[i]) / n) << ">";
+                    out << " <" << _tapn.getPlaces()[i]->getName() << ";" << (((double) _placesStatistics[i]) / n) << ">";
                 }
             }
             out << std::endl;

--- a/src/DiscreteVerification/VerificationTypes/SMCVerification.cpp
+++ b/src/DiscreteVerification/VerificationTypes/SMCVerification.cpp
@@ -127,7 +127,7 @@ void SMCVerification::printTransitionStatistics() const {
 }
 
 void SMCVerification::printPlaceStatistics() {
-    runGenerator.printPlaceStatistics(std::cout);
+    runGenerator.printPlaceStatistics(std::cout, numberOfRuns);
 }
 
 unsigned int SMCVerification::maxUsedTokens() {

--- a/src/DiscreteVerification/VerificationTypes/SMCVerification.cpp
+++ b/src/DiscreteVerification/VerificationTypes/SMCVerification.cpp
@@ -49,6 +49,8 @@ bool SMCVerification::parallel_run() {
                 }
                 generator.reset();
             }
+            std::lock_guard<std::mutex> lock(run_res_mutex);
+            runGenerator.mergeStatistics(generator);
         });
         handles.push_back(handle);
     }

--- a/src/DiscreteVerification/VerificationTypes/SMCVerification.cpp
+++ b/src/DiscreteVerification/VerificationTypes/SMCVerification.cpp
@@ -123,7 +123,11 @@ void SMCVerification::printStats() {
 }
 
 void SMCVerification::printTransitionStatistics() const {
-    runGenerator.printTransitionStatistics(std::cout);
+    runGenerator.printTransitionStatistics(std::cout, numberOfRuns);
+}
+
+void SMCVerification::printPlaceStatistics() {
+    runGenerator.printPlaceStatistics(std::cout);
 }
 
 unsigned int SMCVerification::maxUsedTokens() {


### PR DESCRIPTION
Added statistics for average number of transition firings for each transition, and average max amount of tokens in each place, over the total amount of runs executed when doing SMC verification.