### PR TITLE
Fix for integer overflow in statistics

### DIFF
--- a/include/DiscreteVerification/VerificationTypes/ProbabilityEstimation.hpp
+++ b/include/DiscreteVerification/VerificationTypes/ProbabilityEstimation.hpp
@@ -36,7 +36,7 @@ class ProbabilityEstimation : public SMCVerification {
         void printViolatingRunsStats();
         void printGlobalRunsStats();
 
-        static void printRunsStats(const std::string category, unsigned long n, unsigned long totalSteps, double totalDelay, std::vector<int> perStep, std::vector<float> perDelay);
+        static void printRunsStats(const std::string category, uint64_t n, uint64_t totalSteps, double totalDelay, std::vector<uint64_t> perStep, std::vector<float> perDelay);
 
         void printCumulativeStats();
 
@@ -46,16 +46,16 @@ class ProbabilityEstimation : public SMCVerification {
 
     protected:
 
-        unsigned int runsNeeded;
-        unsigned int validRuns;
+        uint64_t runsNeeded;
+        uint64_t validRuns;
         double validRunsTime = 0;
-        unsigned long validRunsSteps = 0;
+        uint64_t validRunsSteps = 0;
         double violatingRunTime = 0;
-        unsigned long violatingRunSteps = 0;
+        uint64_t violatingRunSteps = 0;
 
-        std::vector<int> validPerStep;
+        std::vector<uint64_t> validPerStep;
         std::vector<float> validPerDelay;
-        std::vector<int> violatingPerStep;
+        std::vector<uint64_t> violatingPerStep;
         std::vector<float> violatingPerDelay;
         float maxValidDuration = 0.0f;
 

--- a/include/DiscreteVerification/VerificationTypes/SMCVerification.hpp
+++ b/include/DiscreteVerification/VerificationTypes/SMCVerification.hpp
@@ -71,9 +71,9 @@ class SMCVerification : public Verification<RealMarking> {
         SMCRunGenerator runGenerator;
         SMCSettings smcSettings;
         size_t numberOfRuns;
-        unsigned int maxTokensSeen;
+        uint64_t maxTokensSeen;
         double totalTime = 0;
-        unsigned long totalSteps = 0;
+        uint64_t totalSteps = 0;
         int64_t durationNs = 0;
 
         std::mutex run_res_mutex;

--- a/src/DiscreteVerification/VerificationTypes/ProbabilityEstimation.cpp
+++ b/src/DiscreteVerification/VerificationTypes/ProbabilityEstimation.cpp
@@ -107,7 +107,7 @@ void ProbabilityEstimation::printViolatingRunsStats() {
     }
 }
 
-void ProbabilityEstimation::printRunsStats(const std::string category, unsigned long n, unsigned long totalSteps, double totalDelay, std::vector<int> perStep, std::vector<float> perDelay) {
+void ProbabilityEstimation::printRunsStats(const std::string category, uint64_t n, uint64_t totalSteps, double totalDelay, std::vector<uint64_t> perStep, std::vector<float> perDelay) {
     if(n == 0) {
         std::cout << "  no " + category + " runs, unable to compute specific statistics" << std::endl;
         return;


### PR DESCRIPTION
Switched to uint64 for statistics, in order to prevent overflow when a large number of runs are executed. It should, however, take more RAM.