### PR TITLE
Fixing floating point error in SMC

### DIFF
--- a/include/Core/TAPN/StochasticStructure.hpp
+++ b/include/Core/TAPN/StochasticStructure.hpp
@@ -89,7 +89,7 @@ namespace VerifyTAPN::SMC {
         DistributionParameters parameters;
 
         template<typename T>
-        double sample(T& engine) const {
+        double sample(T& engine, int& index) const {
             double date = 0;
             switch(type) {
                 case Constant:
@@ -124,8 +124,8 @@ namespace VerifyTAPN::SMC {
                     date = std::lognormal_distribution(parameters.logNormal.logMean, parameters.logNormal.logStddev)(engine);
                     break;
                 case Custom:
-                    int index = std::uniform_int_distribution(parameters.custom.len)(engine);
                     date = parameters.custom.values[index];
+                    index = (index + 1) % parameters.custom.len;
                     break;
             }
             return std::max(date, 0.0);

--- a/include/Core/TAPN/StochasticStructure.hpp
+++ b/include/Core/TAPN/StochasticStructure.hpp
@@ -82,7 +82,7 @@ namespace VerifyTAPN::SMC {
         DistributionParameters parameters;
 
         template<typename T>
-        double sample(T& engine, const unsigned int precision = 0) const {
+        double sample(T& engine) const {
             double date = 0;
             switch(type) {
                 case Constant:
@@ -116,10 +116,6 @@ namespace VerifyTAPN::SMC {
                 case LogNormal: 
                     date = std::lognormal_distribution(parameters.logNormal.logMean, parameters.logNormal.logStddev)(engine);
                     break;
-            }
-            if(precision > 0) {
-                double factor = pow(10.0, precision);
-                date = round(date * factor) / factor;
             }
             return std::max(date, 0.0);
         }

--- a/include/Core/TAPN/StochasticStructure.hpp
+++ b/include/Core/TAPN/StochasticStructure.hpp
@@ -25,7 +25,8 @@ namespace VerifyTAPN::SMC {
         DiscreteUniform,
         Geometric,
         Triangular,
-        LogNormal
+        LogNormal,
+        Custom
     };
 
     std::string distributionName(DistributionType type);
@@ -64,6 +65,10 @@ namespace VerifyTAPN::SMC {
         double logMean;
         double logStddev;
     };
+    struct SMCCustomParameters {
+        std::vector<double> values;
+        size_t index = 0;
+    };
 
     union DistributionParameters {
         SMCUniformParameters uniform;
@@ -75,6 +80,7 @@ namespace VerifyTAPN::SMC {
         SMCGeometricParameters geometric;
         SMCTriangularParameters triangular;
         SMCLogNormalParameters logNormal;
+        SMCCustomParameters custom;
     };
 
     struct Distribution {
@@ -115,6 +121,10 @@ namespace VerifyTAPN::SMC {
                     break;
                 case LogNormal: 
                     date = std::lognormal_distribution(parameters.logNormal.logMean, parameters.logNormal.logStddev)(engine);
+                    break;
+                case Custom:
+                    date = parameters.custom.values[parameters.custom.index];
+                    parameters.custom.index = (parameters.custom.index + 1) % parameters.custom.values.size();
                     break;
             }
             return std::max(date, 0.0);

--- a/include/Core/TAPN/StochasticStructure.hpp
+++ b/include/Core/TAPN/StochasticStructure.hpp
@@ -4,6 +4,7 @@
 #include <random>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace VerifyTAPN::SMC {
 
@@ -66,8 +67,8 @@ namespace VerifyTAPN::SMC {
         double logStddev;
     };
     struct SMCCustomParameters {
-        std::vector<double> values;
-        size_t index = 0;
+        double* values;
+        int len;
     };
 
     union DistributionParameters {
@@ -123,8 +124,8 @@ namespace VerifyTAPN::SMC {
                     date = std::lognormal_distribution(parameters.logNormal.logMean, parameters.logNormal.logStddev)(engine);
                     break;
                 case Custom:
-                    date = parameters.custom.values[parameters.custom.index];
-                    parameters.custom.index = (parameters.custom.index + 1) % parameters.custom.values.size();
+                    int index = std::uniform_int_distribution(parameters.custom.len)(engine);
+                    date = parameters.custom.values[index];
                     break;
             }
             return std::max(date, 0.0);

--- a/include/Core/TAPN/TimeInterval.hpp
+++ b/include/Core/TAPN/TimeInterval.hpp
@@ -14,7 +14,7 @@ namespace VerifyTAPN { namespace TAPN {
         TimeInterval() : leftStrict(false), lowerBound(0), upperBound(std::numeric_limits<int>::max()),
                          rightStrict(true) {};
 
-        TimeInterval(bool leftStrict, int lowerBound, int upperBound, bool rightStrict) : leftStrict(leftStrict),
+        TimeInterval(bool leftStrict, uint64_t lowerBound, uint64_t upperBound, bool rightStrict) : leftStrict(leftStrict),
                                                                                           lowerBound(lowerBound),
                                                                                           upperBound(upperBound),
                                                                                           rightStrict(
@@ -26,21 +26,21 @@ namespace VerifyTAPN { namespace TAPN {
 
         virtual ~TimeInterval() { /* empty */ }
 
-        void divideBoundsBy(int divider);
+        void divideBoundsBy(uint64_t divider);
 
 
     public: // inspectors
         void print(std::ostream &out) const;
 
-        inline int getLowerBound() const { return lowerBound; }
+        inline uint64_t getLowerBound() const { return lowerBound; }
 
-        inline int getUpperBound() const { return upperBound; }
+        inline uint64_t getUpperBound() const { return upperBound; }
 
         inline bool isLowerBoundStrict() const { return leftStrict; }
 
         inline bool isUpperBoundStrict() const { return rightStrict; }
 
-        inline bool setUpperBound(int bound, bool isStrict) {
+        inline bool setUpperBound(uint64_t bound, bool isStrict) {
             if (upperBound == bound) rightStrict |= isStrict;
             else if (upperBound > bound) {
                 rightStrict = isStrict;
@@ -55,6 +55,10 @@ namespace VerifyTAPN { namespace TAPN {
         }
 
         inline bool contains(int number) const {
+            return number >= lowerBound && number <= upperBound;
+        }
+
+        inline bool contains(uint64_t number) const {
             return number >= lowerBound && number <= upperBound;
         }
 
@@ -85,8 +89,8 @@ namespace VerifyTAPN { namespace TAPN {
 
     private: // data
         bool leftStrict;
-        int lowerBound;
-        int upperBound;
+        uint64_t lowerBound;
+        uint64_t upperBound;
         bool rightStrict;
     };
 

--- a/include/Core/TAPN/TimeInterval.hpp
+++ b/include/Core/TAPN/TimeInterval.hpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <map>
 #include <cassert>
+#include <cstdint>
 
 namespace VerifyTAPN { namespace TAPN {
 
@@ -14,7 +15,7 @@ namespace VerifyTAPN { namespace TAPN {
         TimeInterval() : leftStrict(false), lowerBound(0), upperBound(std::numeric_limits<int>::max()),
                          rightStrict(true) {};
 
-        TimeInterval(bool leftStrict, uint64_t lowerBound, uint64_t upperBound, bool rightStrict) : leftStrict(leftStrict),
+        TimeInterval(bool leftStrict, int lowerBound, int upperBound, bool rightStrict) : leftStrict(leftStrict),
                                                                                           lowerBound(lowerBound),
                                                                                           upperBound(upperBound),
                                                                                           rightStrict(
@@ -26,21 +27,21 @@ namespace VerifyTAPN { namespace TAPN {
 
         virtual ~TimeInterval() { /* empty */ }
 
-        void divideBoundsBy(uint64_t divider);
+        void divideBoundsBy(int divider);
 
 
     public: // inspectors
         void print(std::ostream &out) const;
 
-        inline uint64_t getLowerBound() const { return lowerBound; }
+        inline int getLowerBound() const { return lowerBound; }
 
-        inline uint64_t getUpperBound() const { return upperBound; }
+        inline int getUpperBound() const { return upperBound; }
 
         inline bool isLowerBoundStrict() const { return leftStrict; }
 
         inline bool isUpperBoundStrict() const { return rightStrict; }
 
-        inline bool setUpperBound(uint64_t bound, bool isStrict) {
+        inline bool setUpperBound(int bound, bool isStrict) {
             if (upperBound == bound) rightStrict |= isStrict;
             else if (upperBound > bound) {
                 rightStrict = isStrict;
@@ -55,10 +56,6 @@ namespace VerifyTAPN { namespace TAPN {
         }
 
         inline bool contains(int number) const {
-            return number >= lowerBound && number <= upperBound;
-        }
-
-        inline bool contains(uint64_t number) const {
             return number >= lowerBound && number <= upperBound;
         }
 
@@ -89,8 +86,8 @@ namespace VerifyTAPN { namespace TAPN {
 
     private: // data
         bool leftStrict;
-        uint64_t lowerBound;
-        uint64_t upperBound;
+        int lowerBound;
+        int upperBound;
         bool rightStrict;
     };
 

--- a/include/Core/TAPN/WatchExpression.hpp
+++ b/include/Core/TAPN/WatchExpression.hpp
@@ -32,7 +32,7 @@ namespace VerifyTAPN::TAPN {
         public:
             Watch(TimedArcPetriNet* tapn, ArithmeticExpression* expr) : _expr(expr), _tapn(tapn) { }
 
-            float new_marking(RealMarking* marking);
+            float new_marking(RealMarking* marking, const uint32_t precision);
             void close();
 
             std::string get_plots(const std::string& name) const;

--- a/include/DiscreteVerification/DataStructures/RealMarking.hpp
+++ b/include/DiscreteVerification/DataStructures/RealMarking.hpp
@@ -4,6 +4,9 @@
 #include <vector>
 #include "Core/TAPN/TAPN.hpp"
 #include "DiscreteVerification/DataStructures/NonStrictMarkingBase.hpp"
+#include "DiscreteVerification/Util/ClockValue.hpp"
+
+using namespace VerifyTAPN::DiscreteVerification::Util;
 
 namespace VerifyTAPN::DiscreteVerification {
 
@@ -11,15 +14,15 @@ namespace VerifyTAPN::DiscreteVerification {
 
         private:
 
-            double age;
+            clockValue age;
             int count;
 
         public:
 
-            RealToken(double age, int count) : age(age), count(count) { }
+            RealToken(clockValue value, int count) : age(age), count(count) { }
             RealToken(const RealToken&) = default;
             RealToken(const Token& t) : count(t.getCount()) {
-                age = (double) t.getAge();
+                age = t.getAge();
             }
 
             inline int cmp(const RealToken &t) const {
@@ -33,15 +36,15 @@ namespace VerifyTAPN::DiscreteVerification {
 
             inline int getCount() const { return count; };
 
-            inline double getAge() const { return age; };
+            inline clockValue getAge() const { return age; };
 
-            inline void setAge(double i) { age = i; };
+            inline void setAge(clockValue i) { age = i; };
 
             inline void setCount(int i) { count = i; };
 
             inline void remove(int num) { count = count - num; };
 
-            inline void deltaAge(double x) {
+            inline void deltaAge(clockValue x) {
                 age += x;
             }
 
@@ -82,31 +85,31 @@ namespace VerifyTAPN::DiscreteVerification {
                 return count;
             }
 
-            inline void deltaAge(double x) {
+            inline void deltaAge(clockValue x) {
                 for(auto& token : tokens) {
                     token.deltaAge(x);
                 }
             }
 
-            inline double maxTokenAge() const {
+            inline clockValue maxTokenAge() const {
                 if(tokens.size() == 0) {
-                    return -std::numeric_limits<double>::infinity();
+                    return 0;
                 }
                 return tokens.back().getAge();
             }
 
             void add(RealToken new_token);
 
-            void add(double age = 0.0f) {
+            void add(clockValue age = 0) {
                 add(RealToken(age, 1));
             }
 
             bool remove(RealToken to_remove);
 
-            double availableDelay() const {
-                if(tokens.size() == 0) return std::numeric_limits<double>::infinity();
-                double delay = ((double) place->getInvariant().getBound()) - maxTokenAge();
-                return delay <= 0.0f ? 0.0f : delay;
+            clockValue availableDelay() const {
+                if(tokens.size() == 0) return std::numeric_limits<clockValue>::max();
+                clockValue delay = place->getInvariant().getBound() - maxTokenAge();
+                return delay <= 0 ? 0 : delay;
             }
 
             inline int placeId() const {
@@ -133,7 +136,7 @@ namespace VerifyTAPN::DiscreteVerification {
             RealPlaceList& getPlaceList();
             RealTokenList& getTokenList(int placeId);
 
-            void deltaAge(double x);
+            void deltaAge(clockValue x);
 
             NonStrictMarkingBase generateImage();
 
@@ -145,19 +148,19 @@ namespace VerifyTAPN::DiscreteVerification {
                 return canDeadlock(tapn, maxDelay, false);
             };
 
-            bool removeToken(int placeId, double age);
+            bool removeToken(int placeId, clockValue age);
 
             bool removeToken(int placeId, RealToken &token);
 
             bool removeToken(RealPlace &place, RealToken &token);
 
-            void addTokenInPlace(TAPN::TimedPlace &place, double age = 0.0f);
+            void addTokenInPlace(TAPN::TimedPlace &place, clockValue age = 0);
 
             void addTokenInPlace(RealPlace &place, RealToken &token);
 
             void addTokenInPlace(const TAPN::TimedPlace &place, RealToken &token);
 
-            double availableDelay() const;
+            clockValue availableDelay() const;
 
             void setDeadlocked(const bool dead);
 
@@ -165,11 +168,11 @@ namespace VerifyTAPN::DiscreteVerification {
 
             inline void setGeneratedBy(const TAPN::TimedTransition *generatedBy) { this->generatedBy = generatedBy; }
 
-            inline double getPreviousDelay() const { return fromDelay; }
+            inline clockValue getPreviousDelay() const { return fromDelay; }
 
-            inline double getTotalAge() const { return totalAge; }
+            inline clockValue getTotalAge() const { return totalAge; }
 
-            inline void setPreviousDelay(const double delay) { this->fromDelay = delay; }
+            inline void setPreviousDelay(const clockValue delay) { this->fromDelay = delay; }
 
             bool enables(TAPN::TimedTransition* transition);
 
@@ -181,8 +184,8 @@ namespace VerifyTAPN::DiscreteVerification {
             bool deadlocked;
 
             const TAPN::TimedTransition *generatedBy = nullptr;
-            double fromDelay = 0.0;
-            double totalAge = 0.0;
+            clockValue fromDelay = 0;
+            clockValue totalAge = 0;
 
             static RealTokenList emptyTokenList;
 

--- a/include/DiscreteVerification/DataStructures/RealMarking.hpp
+++ b/include/DiscreteVerification/DataStructures/RealMarking.hpp
@@ -19,7 +19,7 @@ namespace VerifyTAPN::DiscreteVerification {
 
         public:
 
-            RealToken(clockValue value, int count) : age(age), count(count) { }
+            RealToken(clockValue value, int count) : age(value), count(count) { }
             RealToken(const RealToken&) = default;
             RealToken(const Token& t) : count(t.getCount()) {
                 age = t.getAge();
@@ -106,11 +106,14 @@ namespace VerifyTAPN::DiscreteVerification {
 
             bool remove(RealToken to_remove);
 
-            clockValue availableDelay(const uint32_t precision = 0) const {
+            clockValue availableDelay(const uint32_t precision) const {
                 if(tokens.size() == 0) return std::numeric_limits<clockValue>::max();
-                clockValue delay = 
-                    toClock(place->getInvariant().getBound(), precision) - maxTokenAge();
-                return delay <= 0 ? 0 : delay;
+                clockValue bound = toClock(place->getInvariant().getBound(), precision);
+                clockValue maxAge = maxTokenAge();
+                if(bound < maxAge) {
+                    return 0;
+                }
+                return bound - maxAge;
             }
 
             inline int placeId() const {
@@ -161,7 +164,7 @@ namespace VerifyTAPN::DiscreteVerification {
 
             void addTokenInPlace(const TAPN::TimedPlace &place, RealToken &token);
 
-            clockValue availableDelay() const;
+            clockValue availableDelay(const uint32_t precision) const;
 
             void setDeadlocked(const bool dead);
 
@@ -175,7 +178,7 @@ namespace VerifyTAPN::DiscreteVerification {
 
             inline void setPreviousDelay(const clockValue delay) { this->fromDelay = delay; }
 
-            bool enables(TAPN::TimedTransition* transition, const uint32_t precision = 0);
+            bool enables(TAPN::TimedTransition* transition, const uint32_t precision);
 
             unsigned int _thread_id = 0;
 

--- a/include/DiscreteVerification/DataStructures/RealMarking.hpp
+++ b/include/DiscreteVerification/DataStructures/RealMarking.hpp
@@ -106,9 +106,10 @@ namespace VerifyTAPN::DiscreteVerification {
 
             bool remove(RealToken to_remove);
 
-            clockValue availableDelay() const {
+            clockValue availableDelay(const uint32_t precision = 0) const {
                 if(tokens.size() == 0) return std::numeric_limits<clockValue>::max();
-                clockValue delay = place->getInvariant().getBound() - maxTokenAge();
+                clockValue delay = 
+                    toClock(place->getInvariant().getBound(), precision) - maxTokenAge();
                 return delay <= 0 ? 0 : delay;
             }
 
@@ -174,7 +175,7 @@ namespace VerifyTAPN::DiscreteVerification {
 
             inline void setPreviousDelay(const clockValue delay) { this->fromDelay = delay; }
 
-            bool enables(TAPN::TimedTransition* transition);
+            bool enables(TAPN::TimedTransition* transition, const uint32_t precision = 0);
 
             unsigned int _thread_id = 0;
 

--- a/include/DiscreteVerification/Generators/SMCRunGenerator.h
+++ b/include/DiscreteVerification/Generators/SMCRunGenerator.h
@@ -10,12 +10,15 @@
 
 #include "DiscreteVerification/Generators/Generator.h"
 #include "DiscreteVerification/Util/IntervalOps.hpp"
+#include "DiscreteVerification/Util/ClockValue.hpp"
 #include "Core/Query/SMCQuery.hpp"
 #include "DiscreteVerification/DataStructures/RealMarking.hpp"
 #include "Core/TAPN/StochasticStructure.hpp"
 
 namespace VerifyTAPN {
     namespace DiscreteVerification {
+
+        using Util::clockValue;
 
         class SMCRunGenerator {
 
@@ -55,20 +58,20 @@ namespace VerifyTAPN {
 
             void disableTransitions(RealMarking* marking);
 
-            std::vector<Util::interval<double>> transitionFiringDates(TimedTransition* transi);
-            std::vector<Util::interval<double>> arcFiringDates(TimeInterval time_interval, uint32_t weight, RealTokenList& tokens);
+            std::vector<Util::interval<clockValue>> transitionFiringDates(TimedTransition* transi);
+            std::vector<Util::interval<clockValue>> arcFiringDates(TimeInterval time_interval, uint32_t weight, RealTokenList& tokens);
             
             std::vector<RealToken> removeRandom(RealTokenList& tokenlist, const TimeInterval& interval, const int weight);
             std::vector<RealToken> removeYoungest(RealTokenList& tokenlist, const TimeInterval& interval, const int weight);
             std::vector<RealToken> removeOldest(RealTokenList& tokenlist, const TimeInterval& interval, const int weight);
 
-            std::pair<TimedTransition*, double> getWinnerTransitionAndDelay();
+            std::pair<TimedTransition*, clockValue> getWinnerTransitionAndDelay();
 
             RealMarking* fire(TimedTransition* transi);
 
             bool reachedEnd() const;
 
-            double getRunDelay() const;
+            clockValue getRunDelay() const;
             int getRunSteps() const;
 
             void printTransitionStatistics(std::ostream &out, const size_t& n = 1) const;
@@ -87,16 +90,16 @@ namespace VerifyTAPN {
             
             bool _maximal = false;
             TimedArcPetriNet& _tapn;
-            std::vector<std::vector<Util::interval<double>>> _defaultTransitionIntervals; // Type not pretty, but need disjoint intervals
-            std::vector<std::vector<Util::interval<double>>> _transitionIntervals; // Type not pretty, but need disjoint intervals
-            std::vector<double> _dates_sampled;
+            std::vector<std::vector<Util::interval<clockValue>>> _defaultTransitionIntervals; // Type not pretty, but need disjoint intervals
+            std::vector<std::vector<Util::interval<clockValue>>> _transitionIntervals; // Type not pretty, but need disjoint intervals
+            std::vector<clockValue> _dates_sampled;
             std::vector<uint32_t> _transitionsStatistics;
             std::vector<uint32_t> _currentPlacesStatistics;
             std::vector<uint32_t> _placesStatistics;
             RealMarking* _origin;
             RealMarking* _parent;
-            double _lastDelay = 0;
-            double _totalTime = 0;
+            clockValue _lastDelay = 0;
+            clockValue _totalTime = 0;
             int _totalSteps = 0;
 
             unsigned int _numericPrecision = 0;

--- a/include/DiscreteVerification/Generators/SMCRunGenerator.h
+++ b/include/DiscreteVerification/Generators/SMCRunGenerator.h
@@ -102,7 +102,7 @@ namespace VerifyTAPN {
             clockValue _totalTime = 0;
             int _totalSteps = 0;
 
-            unsigned int _numericPrecision = 0;
+            uint32_t _numericPrecision = 0;
 
             std::ranlux48 _rng;
 

--- a/include/DiscreteVerification/Generators/SMCRunGenerator.h
+++ b/include/DiscreteVerification/Generators/SMCRunGenerator.h
@@ -24,7 +24,7 @@ namespace VerifyTAPN {
 
         public:
 
-            SMCRunGenerator(TAPN::TimedArcPetriNet &tapn, const unsigned int numericPrecision = 0)
+            SMCRunGenerator(TAPN::TimedArcPetriNet &tapn, const unsigned int numericPrecision)
             : _tapn(tapn)
             , _defaultTransitionIntervals(tapn.getTransitions().size()) 
             , _transitionsStatistics(tapn.getTransitions().size(), 0)

--- a/include/DiscreteVerification/Generators/SMCRunGenerator.h
+++ b/include/DiscreteVerification/Generators/SMCRunGenerator.h
@@ -101,6 +101,7 @@ namespace VerifyTAPN {
             clockValue _lastDelay = 0;
             clockValue _totalTime = 0;
             int _totalSteps = 0;
+            int _sample_index = 0;
 
             uint32_t _numericPrecision = 0;
 

--- a/include/DiscreteVerification/Util/ClockValue.hpp
+++ b/include/DiscreteVerification/Util/ClockValue.hpp
@@ -13,6 +13,8 @@ namespace VerifyTAPN::DiscreteVerification::Util {
 
     clockValue toClock(double value, const uint32_t precision);
 
+    clockValue toClock(int value, const uint32_t precision);
+
 }
 
 #endif

--- a/include/DiscreteVerification/Util/ClockValue.hpp
+++ b/include/DiscreteVerification/Util/ClockValue.hpp
@@ -1,11 +1,22 @@
 #include <cstdint>
 
+#include "Core/TAPN/TimedArcPetriNet.hpp"
+
 namespace VerifyTAPN::DiscreteVerification::Util {
 
     typedef uint64_t clockValue;
 
-    double clockToDouble(clockValue value, uint32_t precision = 0);
+    double clockToDouble(clockValue value, const uint32_t precision = 0);
 
-    clockValue doubleToClock(double value, uint32_t precision = 0);
+    clockValue toClock(double value, const uint32_t precision = 0);
+
+    clockValue toClock(int value, const uint32_t precision = 0);
+
+    clockValue toClock(uint64_t value, const uint32_t precision = 0);
+
+    TAPN::TimedArcPetriNet adaptNetToPrecision(
+        const TAPN::TimedArcPetriNet& net, 
+        const uint32_t precision = 0
+    );
 
 }

--- a/include/DiscreteVerification/Util/ClockValue.hpp
+++ b/include/DiscreteVerification/Util/ClockValue.hpp
@@ -1,3 +1,6 @@
+#ifndef CLOCKVALUE_H
+#define CLOCKVALUE_H
+
 #include <cstdint>
 
 #include "Core/TAPN/TimedArcPetriNet.hpp"
@@ -6,17 +9,10 @@ namespace VerifyTAPN::DiscreteVerification::Util {
 
     typedef uint64_t clockValue;
 
-    double clockToDouble(clockValue value, const uint32_t precision = 0);
+    double clockToDouble(clockValue value, const uint32_t precision);
 
-    clockValue toClock(double value, const uint32_t precision = 0);
-
-    clockValue toClock(int value, const uint32_t precision = 0);
-
-    clockValue toClock(uint64_t value, const uint32_t precision = 0);
-
-    TAPN::TimedArcPetriNet adaptNetToPrecision(
-        const TAPN::TimedArcPetriNet& net, 
-        const uint32_t precision = 0
-    );
+    clockValue toClock(double value, const uint32_t precision);
 
 }
+
+#endif

--- a/include/DiscreteVerification/Util/ClockValue.hpp
+++ b/include/DiscreteVerification/Util/ClockValue.hpp
@@ -1,0 +1,11 @@
+#include <cstdint>
+
+namespace VerifyTAPN::DiscreteVerification::Util {
+
+    typedef uint64_t clockValue;
+
+    double clockToDouble(clockValue value, uint32_t precision = 0);
+
+    clockValue doubleToClock(double value, uint32_t precision = 0);
+
+}

--- a/include/DiscreteVerification/Util/IntervalOps.hpp
+++ b/include/DiscreteVerification/Util/IntervalOps.hpp
@@ -66,6 +66,24 @@ namespace VerifyTAPN {
                     }
                 }
 
+                void delta_neg(T dx) {
+                    if(empty()) return;
+                    if(low != boundDown()) {
+                        if(boundDown() + low < dx) {
+                            low = boundDown();
+                        } else {
+                            low -= dx;
+                        }
+                    }
+                    if(high != boundUp()) {
+                        if(boundDown() + high < dx) {
+                            high = boundDown();
+                        } else {
+                            high -= dx;
+                        }
+                    }
+                }
+
                 interval positive() {
                     if(empty() || high < 0) return interval((T) 1,0);
                     return interval(std::max(low, (T) 0), high);

--- a/include/DiscreteVerification/Util/IntervalOps.hpp
+++ b/include/DiscreteVerification/Util/IntervalOps.hpp
@@ -58,29 +58,40 @@ namespace VerifyTAPN {
 
                 void delta(T dx) {
                     if(empty()) return;
-                    if(low != boundDown()) {
-                        low += dx;
-                    }
-                    if(high != boundUp()) {
+                    if(std::numeric_limits<T>::is_integer) {
+                        if(boundUp() - dx < high) {
+                            high = boundUp();
+                        } else {
+                            high += dx;
+                        }
+                        if(boundUp() - dx < low) {
+                            low = boundUp();
+                        } else {
+                            low += dx;
+                        }
+                    } else {
                         high += dx;
+                        low += dx;
                     }
                 }
 
                 void delta_neg(T dx) {
                     if(empty()) return;
-                    if(low != boundDown()) {
-                        if(boundDown() + low < dx) {
+                    if(std::numeric_limits<T>::is_integer) {
+                        if(boundDown() + dx > low) {
                             low = boundDown();
                         } else {
                             low -= dx;
                         }
-                    }
-                    if(high != boundUp()) {
-                        if(boundDown() + high < dx) {
+                        if(boundDown() + dx > high) {
+                            low = boundUp();
                             high = boundDown();
                         } else {
                             high -= dx;
                         }
+                    } else {
+                        high -= dx;
+                        low -= dx;
                     }
                 }
 

--- a/include/DiscreteVerification/VerificationTypes/SMCVerification.hpp
+++ b/include/DiscreteVerification/VerificationTypes/SMCVerification.hpp
@@ -36,7 +36,7 @@ class SMCVerification : public Verification<RealMarking> {
         unsigned int maxUsedTokens() override;
         void setMaxTokensIfGreater(unsigned int i);
 
-        virtual bool reachedRunBound(SMCRunGenerator* generator = nullptr);
+        virtual bool reachedRunBound(clockValue timeBound, int stepBound, SMCRunGenerator* generator = nullptr);
         
         virtual void handleRunResult(const bool res, int steps, double delay, unsigned int thread_id = 0) = 0;
         virtual bool mustDoAnotherRun() = 0;

--- a/src/Core/TAPN/StochasticStructure.cpp
+++ b/src/Core/TAPN/StochasticStructure.cpp
@@ -89,6 +89,10 @@ namespace VerifyTAPN::SMC {
                 params.logNormal.logMean = raw_params[0];
                 params.logNormal.logStddev = raw_params[1];
                 break;
+            case Custom:
+                params.custom.index = 0;
+                params.custom.values = raw_params;
+                break;
             default:
                 break;
         }

--- a/src/Core/TAPN/StochasticStructure.cpp
+++ b/src/Core/TAPN/StochasticStructure.cpp
@@ -1,5 +1,7 @@
 #include "Core/TAPN/StochasticStructure.hpp"
 
+#include <cstring>
+
 namespace VerifyTAPN::SMC {
 
     std::string distributionName(DistributionType type) {
@@ -24,6 +26,8 @@ namespace VerifyTAPN::SMC {
                 return "triangular";
             case LogNormal:
                 return "log normal";
+            case Custom:
+                return "custom";
         }
         return "";
     }
@@ -53,6 +57,7 @@ namespace VerifyTAPN::SMC {
     Distribution Distribution::fromParams(int distrib_id, std::vector<double> raw_params) {
         DistributionType distrib = static_cast<DistributionType>(distrib_id);
         DistributionParameters params;
+        double* values;
         switch(distrib){
             case Constant:
                 params.constant.value = raw_params[0];
@@ -90,8 +95,10 @@ namespace VerifyTAPN::SMC {
                 params.logNormal.logStddev = raw_params[1];
                 break;
             case Custom:
-                params.custom.index = 0;
-                params.custom.values = raw_params;
+                values = (double*) std::malloc(raw_params.size() * sizeof(double));
+                std::memcpy(values, raw_params.data(), raw_params.size() * sizeof(double));
+                params.custom.values = values;
+                params.custom.len = raw_params.size();
                 break;
             default:
                 break;

--- a/src/Core/TAPN/WatchExpression.cpp
+++ b/src/Core/TAPN/WatchExpression.cpp
@@ -2,20 +2,24 @@
 #include "DiscreteVerification/QueryVisitor.hpp"
 #include "DiscreteVerification/DataStructures/RealMarking.hpp"
 
+#include "DiscreteVerification/Util/ClockValue.hpp"
+
 #include <numeric>
 
 using namespace VerifyTAPN::TAPN;
 using VerifyTAPN::DiscreteVerification::RealMarking;
 using VerifyTAPN::DiscreteVerification::QueryVisitor;
 
+using VerifyTAPN::DiscreteVerification::Util::clockToDouble;
+
 using std::vector;
 
-float Watch::new_marking(RealMarking *marking)
+float Watch::new_marking(RealMarking *marking, const uint32_t precision)
 {
     if(_max_step > 0 && marking->getGeneratedBy() == nullptr) {
         return _values.back();
     }
-    float timestamp = marking->getTotalAge();
+    float timestamp = clockToDouble(marking->getTotalAge(), precision);
     QueryVisitor<RealMarking> checker(*marking, *_tapn);
     IntResult res;
     _expr->accept(checker, res);

--- a/src/DiscreteVerification/DataStructures/RealMarking.cpp
+++ b/src/DiscreteVerification/DataStructures/RealMarking.cpp
@@ -154,7 +154,7 @@ void RealMarking::setDeadlocked(const bool dead)
     deadlocked = dead;
 }
 
-bool RealMarking::enables(TAPN::TimedTransition* transition) {
+bool RealMarking::enables(TAPN::TimedTransition* transition, const uint32_t precision) {
     for(auto input : transition->getInhibitorArcs()) {
         uint32_t weight = input->getWeight();
         RealTokenList tokens = getTokenList(input->getInputPlace().getIndex());
@@ -170,10 +170,13 @@ bool RealMarking::enables(TAPN::TimedTransition* transition) {
     }
     for(auto input : transition->getPreset()) {
         TAPN::TimeInterval interval = input->getInterval();
+        clockValue lower = toClock(interval.getLowerBound(), precision);
+        clockValue upper = toClock(interval.getUpperBound(), precision);
         uint32_t weight = input->getWeight();
         RealTokenList tokens = getTokenList(input->getInputPlace().getIndex());
         for(auto& token : tokens) {
-            if(interval.contains(token.getAge())) {
+            clockValue age = token.getAge();
+            if(lower <= age && upper >= age) {
                 if(token.getCount() > weight) {
                     weight = 0;
                 } else {
@@ -189,10 +192,13 @@ bool RealMarking::enables(TAPN::TimedTransition* transition) {
         TAPN::TimeInterval interval = input->getInterval();
         if(outputPlace.getInvariant().getBound() < interval.getUpperBound())
             interval.setUpperBound(outputPlace.getInvariant().getBound(), false);
+        clockValue lower = toClock(interval.getLowerBound(), precision);
+        clockValue upper = toClock(interval.getUpperBound(), precision);
         uint32_t weight = input->getWeight();
         RealTokenList tokens = getTokenList(input->getSource().getIndex());
         for(auto& token : tokens) {
-            if(interval.contains(token.getAge())) {
+            clockValue age = token.getAge();
+            if(lower <= age && upper >= age) {
                 if(token.getCount() > weight) {
                     weight = 0;
                 } else {

--- a/src/DiscreteVerification/DataStructures/RealMarking.cpp
+++ b/src/DiscreteVerification/DataStructures/RealMarking.cpp
@@ -136,12 +136,12 @@ void RealMarking::addTokenInPlace(const TAPN::TimedPlace &place, RealToken &toke
     places[place.getIndex()].add(token);
 }
 
-clockValue RealMarking::availableDelay() const
+clockValue RealMarking::availableDelay(const uint32_t precision) const
 {
     clockValue available = std::numeric_limits<clockValue>::max();
     for(const auto& place : places) {
         if(place.isEmpty()) continue;
-        clockValue delay = place.availableDelay();
+        clockValue delay = place.availableDelay(precision);
         if(delay < available) {
             available = delay;
         }

--- a/src/DiscreteVerification/DataStructures/RealMarking.cpp
+++ b/src/DiscreteVerification/DataStructures/RealMarking.cpp
@@ -75,7 +75,7 @@ RealTokenList& RealMarking::getTokenList(int placeId)
     return places[placeId].tokens;
 }
 
-void RealMarking::deltaAge(double x)
+void RealMarking::deltaAge(clockValue x)
 {
     for(auto& place : places) {
         place.deltaAge(x);
@@ -104,7 +104,7 @@ bool RealMarking::canDeadlock(const TAPN::TimedArcPetriNet &tapn, int maxDelay, 
     return deadlocked;
 }
 
-bool RealMarking::removeToken(int placeId, double age)
+bool RealMarking::removeToken(int placeId, clockValue age)
 {
     RealToken token(age, 1);
     return removeToken(placeId, token);
@@ -120,7 +120,7 @@ bool RealMarking::removeToken(RealPlace &place, RealToken &token)
     return place.remove(token);
 }
 
-void RealMarking::addTokenInPlace(TAPN::TimedPlace &place, double age)
+void RealMarking::addTokenInPlace(TAPN::TimedPlace &place, clockValue age)
 {
     RealToken token(age, 1);
     addTokenInPlace(place, token);
@@ -136,12 +136,12 @@ void RealMarking::addTokenInPlace(const TAPN::TimedPlace &place, RealToken &toke
     places[place.getIndex()].add(token);
 }
 
-double RealMarking::availableDelay() const
+clockValue RealMarking::availableDelay() const
 {
-    double available = std::numeric_limits<double>::infinity();
+    clockValue available = std::numeric_limits<clockValue>::max();
     for(const auto& place : places) {
         if(place.isEmpty()) continue;
-        double delay = place.availableDelay();
+        clockValue delay = place.availableDelay();
         if(delay < available) {
             available = delay;
         }

--- a/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
+++ b/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
@@ -51,7 +51,7 @@ namespace VerifyTAPN {
             _maximal = false;
             _totalTime = 0;
             _totalSteps = 0;
-            _dates_sampled = std::vector<clockValue>(_transitionIntervals.size(), std::numeric_limits<clockValue>::infinity());
+            _dates_sampled = std::vector<clockValue>(_transitionIntervals.size(), std::numeric_limits<clockValue>::max());
             bool deadlocked = true;
             for(int i = 0 ; i < _dates_sampled.size() ; i++) {
                 auto* intervals = &_transitionIntervals[i];
@@ -165,7 +165,7 @@ namespace VerifyTAPN {
             for(int i = 0 ; i < _transitionIntervals.size() ; i++) {
                 clockValue date = _dates_sampled[i];
                 _dates_sampled[i] = (date == std::numeric_limits<clockValue>::max()) ?
-                    std::numeric_limits<clockValue>::infinity() : date - delay;
+                    std::numeric_limits<clockValue>::max() : date - delay;
             }
 
             refreshTransitionsIntervals();
@@ -447,7 +447,7 @@ namespace VerifyTAPN {
 
             for (auto* output : transi->getPostset()) {
                 TimedPlace &place = output->getOutputPlace();
-                RealToken token = RealToken(0.0, output->getWeight());
+                RealToken token = RealToken(0, output->getWeight());
                 child->addTokenInPlace(place, token);
                 int place_i = place.getIndex();
                 if(child->numberOfTokensInPlace(place_i) > _currentPlacesStatistics[place_i]) {

--- a/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
+++ b/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
@@ -57,7 +57,7 @@ namespace VerifyTAPN {
                 auto* intervals = &_transitionIntervals[i];
                 if(!intervals->empty() && intervals->front().lower() == 0) {
                     const Distribution& distrib = _tapn.getTransitions()[i]->getDistribution();
-                    _dates_sampled[i] = distrib.sample(_rng, _numericPrecision);
+                    _dates_sampled[i] = toClock(distrib.sample(_rng), _numericPrecision);
                 }
                 deadlocked &=   _transitionIntervals[i].empty() || 
                                 (
@@ -104,7 +104,7 @@ namespace VerifyTAPN {
                     _dates_sampled[i] = std::numeric_limits<clockValue>::max();
                 } else if(newlyEnabled) {
                     const Distribution& distrib = _tapn.getTransitions()[i]->getDistribution();
-                    clockValue date = distrib.sample(_rng, _numericPrecision);
+                    clockValue date = toClock(distrib.sample(_rng), _numericPrecision);
                     if(_transitionIntervals[i].front().upper() > 0 || date == 0) {
                         _dates_sampled[i] = date;
                     }
@@ -132,6 +132,8 @@ namespace VerifyTAPN {
 
         RealMarking* SMCRunGenerator::next() {
             auto [transi, delay] = getWinnerTransitionAndDelay();
+
+            //std::cout << transi->getName() << " : " << delay << std::endl;
             
             if(delay == std::numeric_limits<clockValue>::max()) {
                 _maximal = true;

--- a/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
+++ b/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
@@ -51,13 +51,14 @@ namespace VerifyTAPN {
             _maximal = false;
             _totalTime = 0;
             _totalSteps = 0;
+            _sample_index = 0;
             _dates_sampled = std::vector<clockValue>(_transitionIntervals.size(), std::numeric_limits<clockValue>::max());
             bool deadlocked = true;
             for(int i = 0 ; i < _dates_sampled.size() ; i++) {
                 auto* intervals = &_transitionIntervals[i];
                 if(!intervals->empty() && intervals->front().lower() == 0) {
                     const Distribution& distrib = _tapn.getTransitions()[i]->getDistribution();
-                    _dates_sampled[i] = toClock(distrib.sample(_rng), _numericPrecision);
+                    _dates_sampled[i] = toClock(distrib.sample(_rng, _sample_index), _numericPrecision);
                 }
                 deadlocked &=   _transitionIntervals[i].empty() || 
                                 (
@@ -104,7 +105,7 @@ namespace VerifyTAPN {
                     _dates_sampled[i] = std::numeric_limits<clockValue>::max();
                 } else if(newlyEnabled) {
                     const Distribution& distrib = _tapn.getTransitions()[i]->getDistribution();
-                    clockValue date = toClock(distrib.sample(_rng), _numericPrecision);
+                    clockValue date = toClock(distrib.sample(_rng, _sample_index), _numericPrecision);
                     if(_transitionIntervals[i].front().upper() > 0 || date == 0) {
                         _dates_sampled[i] = date;
                     }

--- a/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
+++ b/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
@@ -15,7 +15,7 @@
 namespace VerifyTAPN {
     namespace DiscreteVerification {
 
-        using Util::interval;
+        using namespace Util;
 
         void SMCRunGenerator::prepare(RealMarking *parent) {
             _origin = new RealMarking(*parent);
@@ -271,7 +271,9 @@ namespace VerifyTAPN {
 
         std::vector<interval<clockValue>> SMCRunGenerator::arcFiringDates(TimeInterval time_interval, uint32_t weight, RealTokenList& tokens) {
             // We assume tokens is SORTED !
-            Util::interval<clockValue> arcInterval(time_interval.getLowerBound(), time_interval.getUpperBound());
+            clockValue lower = toClock(time_interval.getLowerBound(), _numericPrecision);
+            clockValue upper = toClock(time_interval.getUpperBound(), _numericPrecision);
+            Util::interval<clockValue> arcInterval(lower, upper);
             size_t total_tokens = 0;
             for(auto &t : tokens) {
                 total_tokens += t.getCount();
@@ -305,10 +307,13 @@ namespace VerifyTAPN {
             std::uniform_int_distribution<> randomTokenIndex(0, tokenList.size() - 1);
             size_t tok_index = randomTokenIndex(_rng);
             size_t tested = 0;
+            clockValue lower = toClock(interval.getLowerBound(), _numericPrecision);
+            clockValue upper = toClock(interval.getUpperBound(), _numericPrecision);
             while(remaining > 0 && tested < tokenList.size()) {
                 RealToken& token = tokenList[tok_index];
-                if(interval.contains(token.getAge())) {
-                    res.push_back(RealToken(token.getAge(), 1));
+                clockValue age = token.getAge();
+                if(lower <= age && upper >= age) {
+                    res.push_back(RealToken(age, 1));
                     remaining--;
                     tokenList[tok_index].remove(1);
                     if(tokenList[tok_index].getCount() == 0) {
@@ -332,9 +337,11 @@ namespace VerifyTAPN {
             std::vector<RealToken> res;
             int remaining = weight;
             auto iter = tokenList.begin();
+            clockValue lower = toClock(interval.getLowerBound(), _numericPrecision);
+            clockValue upper = toClock(interval.getUpperBound(), _numericPrecision);
             while(iter != tokenList.end()) {
                 clockValue age = iter->getAge();
-                if(!interval.contains(age)) {
+                if(lower > age || upper < age) {
                     iter++;
                     continue;
                 }
@@ -359,9 +366,11 @@ namespace VerifyTAPN {
             std::vector<RealToken> res;
             int remaining = weight;
             auto iter = tokenList.rbegin();
+            clockValue lower = toClock(interval.getLowerBound(), _numericPrecision);
+            clockValue upper = toClock(interval.getUpperBound(), _numericPrecision);
             while(iter != tokenList.rend()) {
                 clockValue age = iter->getAge();
-                if(!interval.contains(age)) {
+                if(lower > age || upper < age) {
                     iter++;
                     continue;
                 }

--- a/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
+++ b/src/DiscreteVerification/Generators/SMCRunGenerator.cpp
@@ -132,8 +132,6 @@ namespace VerifyTAPN {
 
         RealMarking* SMCRunGenerator::next() {
             auto [transi, delay] = getWinnerTransitionAndDelay();
-
-            std::cout << "DELAY: " << delay << std::endl;
             
             if(delay == std::numeric_limits<clockValue>::max()) {
                 _maximal = true;
@@ -145,16 +143,15 @@ namespace VerifyTAPN {
                 _trace.push_back(_parent);
             }
 
-            std::cout << "Marking ---------------" << std::endl;
-            for(auto& place : _parent->getPlaceList()) {
-                if(place.numberOfTokens() == 0) continue;
-                std::cout << "place " << place.placeId() << " ";
-                for(auto& tok : place.tokens) {
-                    std::cout << tok.getAge() << ", ";
-                }
-                std::cout << std::endl;
-            }
-            std::cout << "----------------------" << std::endl;
+            // std::cout << "Marking ---------------" << std::endl;
+            // for(auto& place : _parent->getPlaceList()) {
+            //     if(place.numberOfTokens() == 0) continue;
+            //     std::cout << "place " << place.placeId() << " ";
+            //     for(auto& tok : place.tokens) {
+            //         std::cout << tok.getAge() << ", ";
+            //     }
+            //     std::cout << std::endl;
+            // }
 
             _parent->deltaAge(delay);
 
@@ -306,7 +303,6 @@ namespace VerifyTAPN {
                         for(auto age : selected) {
                             interval<clockValue> shifted = arcInterval;
                             shifted.delta_neg(age);
-                            std::cout << shifted.lower() << "," << shifted.upper() << std::endl;
                             tokenSetInterval = Util::intersect(tokenSetInterval, shifted);
                         }
                         Util::setAdd(firingDates, tokenSetInterval);
@@ -324,16 +320,11 @@ namespace VerifyTAPN {
             size_t tested = 0;
             clockValue lower = toClock(interval.getLowerBound(), _numericPrecision);
             clockValue upper = toClock(interval.getUpperBound(), _numericPrecision);
-            std::cout << "Need to find " << remaining << std::endl;
-            std::cout << "In: " << lower << " , " << upper << std::endl;
-            std::cout << "prev: " << interval.getLowerBound() << " , " << interval.getUpperBound() << std::endl;
             while(remaining > 0 && tested < tokenList.size()) {
                 RealToken& token = tokenList[tok_index];
                 clockValue age = token.getAge();
-                std::cout << "- Age: " << age << std::endl;
                 if(lower <= age && upper >= age) {
                     res.push_back(RealToken(age, 1));
-                    std::cout << "Found token of age " << age << std::endl;
                     remaining--;
                     tokenList[tok_index].remove(1);
                     if(tokenList[tok_index].getCount() == 0) {
@@ -422,7 +413,6 @@ namespace VerifyTAPN {
             for (auto &input : transi->getPreset()) {
                 RealPlace& place = placelist[input->getInputPlace().getIndex()];
                 RealTokenList& tokenList = place.tokens;
-                std::cout << "Firing frome place " << place.placeId() << "-----------" << std::endl;
                 switch(transi->getFiringMode()) {
                     case SMC::Random:
                         removeRandom(tokenList, input->getInterval(), input->getWeight());

--- a/src/DiscreteVerification/Util/CMakeLists.txt
+++ b/src/DiscreteVerification/Util/CMakeLists.txt
@@ -1,2 +1,2 @@
 
-add_library(Util IntervalOps.cpp)
+add_library(Util IntervalOps.cpp ClockValue.cpp)

--- a/src/DiscreteVerification/Util/ClockValue.cpp
+++ b/src/DiscreteVerification/Util/ClockValue.cpp
@@ -2,40 +2,34 @@
 
 #include <math.h>
 
+#define MAX_PRECISION 10
+
 namespace VerifyTAPN::DiscreteVerification::Util {
 
 using VerifyTAPN::TAPN::TimedArcPetriNet;
 
 double clockToDouble(clockValue value, const uint32_t precision)
 {
+    double time = static_cast<double>(value);
+    if(precision > 0) {
+        time /= pow(10.0, precision);
+    } else {
+        time /= pow(10.0, MAX_PRECISION);
+    }
     return 0.0;
 }
 
 clockValue toClock(double value, const uint32_t precision)
 {
-    if(precision > 0) {
-        
+    if(value == std::numeric_limits<double>::infinity()) {
+        return std::numeric_limits<clockValue>::max();
     }
-    
-    return 0;
-}
-
-clockValue toClock(int value, const uint32_t precision)
-{
     if(precision > 0) {
-        
+        value *= pow(10.0, precision);
+    } else {
+        value *= pow(10.0, MAX_PRECISION);
     }
-    
-    return 0;
-}
-
-clockValue toClock(uint64_t value, const uint32_t precision)
-{
-    if(precision > 0) {
-        
-    }
-    
-    return 0;
+    return static_cast<clockValue>(value);
 }
 
 }

--- a/src/DiscreteVerification/Util/ClockValue.cpp
+++ b/src/DiscreteVerification/Util/ClockValue.cpp
@@ -10,13 +10,16 @@ using VerifyTAPN::TAPN::TimedArcPetriNet;
 
 double clockToDouble(clockValue value, const uint32_t precision)
 {
+    if(value == std::numeric_limits<clockValue>::max()) {
+        return std::numeric_limits<double>::infinity();
+    }
     double time = static_cast<double>(value);
     if(precision > 0) {
         time /= pow(10.0, precision);
     } else {
         time /= pow(10.0, MAX_PRECISION);
     }
-    return 0.0;
+    return time;
 }
 
 clockValue toClock(double value, const uint32_t precision)
@@ -30,6 +33,20 @@ clockValue toClock(double value, const uint32_t precision)
         value *= pow(10.0, MAX_PRECISION);
     }
     return static_cast<clockValue>(value);
+}
+
+clockValue toClock(int value, const uint32_t precision)
+{
+    if(value == std::numeric_limits<int>::max()) {
+        return std::numeric_limits<clockValue>::max();
+    }
+    clockValue res = value;
+    if(precision > 0) {
+        res *= pow(10, precision);
+    } else {
+        res *= pow(10, MAX_PRECISION);
+    }
+    return res;
 }
 
 }

--- a/src/DiscreteVerification/Util/ClockValue.cpp
+++ b/src/DiscreteVerification/Util/ClockValue.cpp
@@ -4,12 +4,32 @@
 
 namespace VerifyTAPN::DiscreteVerification::Util {
 
-double clockToDouble(clockValue value, uint32_t precision)
+using VerifyTAPN::TAPN::TimedArcPetriNet;
+
+double clockToDouble(clockValue value, const uint32_t precision)
 {
     return 0.0;
 }
 
-clockValue doubleToClock(double value, uint32_t precision)
+clockValue toClock(double value, const uint32_t precision)
+{
+    if(precision > 0) {
+        
+    }
+    
+    return 0;
+}
+
+clockValue toClock(int value, const uint32_t precision)
+{
+    if(precision > 0) {
+        
+    }
+    
+    return 0;
+}
+
+clockValue toClock(uint64_t value, const uint32_t precision)
 {
     if(precision > 0) {
         

--- a/src/DiscreteVerification/Util/ClockValue.cpp
+++ b/src/DiscreteVerification/Util/ClockValue.cpp
@@ -1,0 +1,21 @@
+#include "DiscreteVerification/Util/ClockValue.hpp"
+
+#include <math.h>
+
+namespace VerifyTAPN::DiscreteVerification::Util {
+
+double clockToDouble(clockValue value, uint32_t precision)
+{
+    return 0.0;
+}
+
+clockValue doubleToClock(double value, uint32_t precision)
+{
+    if(precision > 0) {
+        
+    }
+    
+    return 0;
+}
+
+}

--- a/src/DiscreteVerification/VerificationTypes/ProbabilityComparison.cpp
+++ b/src/DiscreteVerification/VerificationTypes/ProbabilityComparison.cpp
@@ -9,7 +9,7 @@ ProbabilityComparison::ProbabilityComparison(
     TAPN::TimedArcPetriNet &tapn, RealMarking &initialMarking, AST::SMCQuery *query_1, AST::SMCQuery *query_2, VerificationOptions options
 ) : Verification(tapn, initialMarking, query_1, options), maxTokensSeen(0), numberOfRuns(0), result(0), mayBeIndifferent(true),
     acceptingRuns(0), ratio_indifferent(0), finished(false),
-    runGenerator(tapn)
+    runGenerator(tapn, options.getSMCNumericPrecision())
 {
     this->query_1 = query_1;
     this->query_2 = query_2;

--- a/src/DiscreteVerification/VerificationTypes/ProbabilityEstimation.cpp
+++ b/src/DiscreteVerification/VerificationTypes/ProbabilityEstimation.cpp
@@ -61,7 +61,7 @@ bool ProbabilityEstimation::handleSuccessor(RealMarking* marking) {
 
     for(int i = 0 ; i < watchs.size() ; i++) {
         Watch& w = watchs[i][marking->_thread_id];
-        w.new_marking(marking);
+        w.new_marking(marking, options.getSMCNumericPrecision());
     }
 
     delete marking;

--- a/src/DiscreteVerification/VerificationTypes/SMCTracesGenerator.cpp
+++ b/src/DiscreteVerification/VerificationTypes/SMCTracesGenerator.cpp
@@ -28,7 +28,7 @@ bool SMCTracesGenerator::handleSuccessor(RealMarking* marking) {
 
     for(int i = 0 ; i < watchs.size() ; i++) {
         Watch& w = watchs[i][marking->_thread_id];
-        w.new_marking(marking);
+        w.new_marking(marking, options.getSMCNumericPrecision());
     }
 
     delete marking;

--- a/src/DiscreteVerification/VerificationTypes/SMCVerification.cpp
+++ b/src/DiscreteVerification/VerificationTypes/SMCVerification.cpp
@@ -85,6 +85,7 @@ bool SMCVerification::run() {
         bool runRes = executeRun();
         double runDuration = std::min(runGenerator.getRunDelay(), timeBound);
         int runSteps = std::min(runGenerator.getRunSteps(), smcSettings.stepBound);
+        std::cout << runSteps << std::endl; 
         handleRunResult(runRes, runSteps, runDuration);
         if(mustSaveTrace()) handleTrace(runRes);
         runGenerator.recordTrace = mustSaveTrace();

--- a/src/DiscreteVerification/VerificationTypes/SMCVerification.cpp
+++ b/src/DiscreteVerification/VerificationTypes/SMCVerification.cpp
@@ -83,9 +83,8 @@ bool SMCVerification::run() {
     clockValue timeBound = toClock(smcSettings.timeBound, options.getSMCNumericPrecision());
     while(mustDoAnotherRun()) {
         bool runRes = executeRun();
-        double runDuration = std::min(runGenerator.getRunDelay(), timeBound);
+        double runDuration = clockToDouble(std::min(runGenerator.getRunDelay(), timeBound), options.getSMCNumericPrecision());
         int runSteps = std::min(runGenerator.getRunSteps(), smcSettings.stepBound);
-        std::cout << runSteps << std::endl; 
         handleRunResult(runRes, runSteps, runDuration);
         if(mustSaveTrace()) handleTrace(runRes);
         runGenerator.recordTrace = mustSaveTrace();


### PR DESCRIPTION
Switching from doubles to a fixed point type to avoid floating point errors when performing SMC queries.